### PR TITLE
Bump lombok version to 1.18.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.6</version>
+                            <version>1.18.20</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
1.18.6 doesn't work with java 16, 1.18.20 works with both 8 and 16