### PR TITLE
Update ProtocolLib and fix sendAddPotionEffect for 1.18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Feel free to create Pull Requests if you'd like to improve SuperVanish! Please r
         <dependency>
             <groupId>com.github.LeonMangler</groupId>
             <artifactId>SuperVanish</artifactId>
-            <version>6.2.6-4</version>
+            <version>6.2.6-5</version>
         </dependency>
     </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.myzelyam</groupId>
     <artifactId>SuperVanish</artifactId>
-    <version>6.2.6-4</version>
+    <version>6.2.6-5</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
             <scope>provided</scope>
         </dependency>
         <!--Vault API-->

--- a/src/main/java/de/myzelyam/supervanish/features/NightVision.java
+++ b/src/main/java/de/myzelyam/supervanish/features/NightVision.java
@@ -98,12 +98,26 @@ public class NightVision extends Feature implements Runnable {
         int amplifier = effect.getAmplifier();
         int duration = effect.getDuration();
         int entityID = p.getEntityId();
-        packet.getIntegers().write(0, entityID);
-        packet.getBytes().write(0, (byte) effectID);
-        packet.getBytes().write(1, (byte) amplifier);
-        packet.getIntegers().write(1, duration);
-        // hide particles in 1.9
-        packet.getBytes().write(2, (byte) 0);
+
+	// server version check and code for 1.18+
+	if (plugin.getVersionUtil().isOneDotXOrHigher(18)) {
+       	    packet.getIntegers().write(0, entityID);
+       	    packet.getIntegers().write(1, effectID);
+       	    packet.getBytes().write(0, (byte) amplifier);
+       	    packet.getIntegers().write(2, duration);
+
+	    // bit-field rather than a byte enum in 1.18+
+            packet.getBytes().write(1, (byte) 0);
+	} else {
+       	    packet.getIntegers().write(0, entityID);
+       	    packet.getBytes().write(0, (byte) effectID);
+       	    packet.getBytes().write(1, (byte) amplifier);
+       	    packet.getIntegers().write(1, duration);
+	
+            // hide particles in 1.9
+            packet.getBytes().write(2, (byte) 0);
+	}
+
         try {
             ProtocolLibrary.getProtocolManager().sendServerPacket(p, packet);
         } catch (InvocationTargetException e) {


### PR DESCRIPTION
I noticed that when using SuperVanish on 1.18+ Minecraft servers a `FieldAccessException` would get thrown and a large stack trace printed in the logs.  This was caused by code in the `sendAddPotionEffect` method which was written to populate the `Entity Effect` data structure and that structure had changed in the recent 1.18+ API.

I also used this opportunity to update ProtocolLib from version 4.7.0 to 4.8.0.