### PR TITLE
Remove unnecessary checks and enable resource filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <repositories>

--- a/src/main/java/de/myzelyam/supervanish/features/SilentOpenChest.java
+++ b/src/main/java/de/myzelyam/supervanish/features/SilentOpenChest.java
@@ -149,9 +149,7 @@ public class SilentOpenChest extends Feature {
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (p.getGameMode() == GameMode.SPECTATOR) return;
         //noinspection deprecation
-        if (p.isSneaking() && p.getItemInHand() != null
-                && (p.getItemInHand().getType().isBlock() || p.getItemInHand().getType() == ITEM_FRAME)
-                && p.getItemInHand().getType() != Material.AIR)
+        if (p.isSneaking() && p.getItemInHand().getType() != Material.AIR)
             return;
         Block block = e.getClickedBlock();
         if (block == null) return;

--- a/src/main/java/de/myzelyam/supervanish/features/SilentOpenChest.java
+++ b/src/main/java/de/myzelyam/supervanish/features/SilentOpenChest.java
@@ -149,7 +149,8 @@ public class SilentOpenChest extends Feature {
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (p.getGameMode() == GameMode.SPECTATOR) return;
         //noinspection deprecation
-        if (p.isSneaking() && p.getItemInHand().getType() != Material.AIR)
+        // Remember to keep "p.getItemInHand() != null" as we can't ensure that older Spigot versions will always return a non-null value
+        if (p.isSneaking() && p.isSneaking() && p.getItemInHand() != null && p.getItemInHand().getType() != Material.AIR)
             return;
         Block block = e.getClickedBlock();
         if (block == null) return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-# SuperVanish v6.2.9 - Configuration
+# SuperVanish v${project.version} - Configuration
 
 ############# Invisibility Features ##############
 InvisibilityFeatures:
@@ -174,4 +174,4 @@ MiscellaneousOptions:
     NotifyAdmins: true
 
 ################# Do Not Touch ###################
-ConfigVersion: 6.2.9
+ConfigVersion: ${project.version}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,4 +1,4 @@
-# SuperVanish v6.2.9 - Messages
+# SuperVanish v${project.version} - Messages
 #
 # Information:
 # <..> means that .. is required; [..] means that .. is optional and can be left out; | inside [] or <> stands for 'OR'
@@ -71,4 +71,4 @@ Messages:
   DynmapFakeQuit: '%d% quit'
   HelpHeader: "&a<---------------&e SuperVanish-Help &a--------------->"
   HelpFormat: "&6%usage% &7- &b%description% &c(%permission%)"
-MessagesVersion: 6.2.9
+MessagesVersion: ${project.version}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: SuperVanish
 main: de.myzelyam.supervanish.SuperVanish
 author: MyzelYam
 description: Advanced /vanish plugin which makes other players think that you're not on the server
-version: 6.2.8
+version: ${project.version}
 api-version: 1.13
 website: https://www.spigotmc.org/resources/supervanish-be-invisible.1331/
 softdepend:


### PR DESCRIPTION
This PR proposes two changes. Firstly, I have detected an edge case where shift-right-clicking a chest while vanished, with silent chests enabled and with a glowing item frame, the plugin will open the chest (silently) instead, whereas, with a standard item frame, this does not happen: the item frame is placed on the side of the chest that the player is facing. To avoid covering every possible edge case that exists now and that may be added in the future, I have made the conditions less specific: the plugin will now only open a chest if the player isn't holding anything. I also removed a null check, as the Bukkit API should never return null for ``Player#getItemInHand()``.

Lastly, I've enabled resource filtering so that the version number is automatically populated in the plugin.yml file, using the version number from the pom.xml.