### PR TITLE
Add check for tilting of DripLeaves.

### DIFF
--- a/src/main/java/de/myzelyam/supervanish/features/FeatureMgr.java
+++ b/src/main/java/de/myzelyam/supervanish/features/FeatureMgr.java
@@ -45,6 +45,8 @@ public class FeatureMgr {
         registeredFeatures.put("Broadcast", new FeatureInfo(Broadcast.class, plugin));
         registeredFeatures.put("NoSculkSensorDetection", new FeatureInfo(NoSculkSensorDetection.class, plugin,
                 Collections.singletonList(oneDotSeventeenOrHigher)));
+        registeredFeatures.put("NoDripLeafTilt", new FeatureInfo(NoDripLeafTilt.class, plugin,
+            Collections.singletonList(oneDotSeventeenOrHigher)));
     }
 
     public void enableFeatures() {

--- a/src/main/java/de/myzelyam/supervanish/features/NoDripLeafTilt.java
+++ b/src/main/java/de/myzelyam/supervanish/features/NoDripLeafTilt.java
@@ -1,6 +1,7 @@
 package de.myzelyam.supervanish.features;
 
 import de.myzelyam.supervanish.SuperVanish;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -12,17 +13,15 @@ public class NoDripLeafTilt extends Feature{
 
   @EventHandler(priority = EventPriority.HIGH)
   public void onInteract(PlayerInteractEvent e) {
-    if(plugin.getSettings().getBoolean("InvisibilityFeatures.DisableDripLeaf")) {
-      String material = e.getClickedBlock().getType().toString();
-      if (material.equals("BIG_DRIPLEAF")) {
-        e.setCancelled(true);
-      }
+    Player p = e.getPlayer();
+    if (!plugin.getVanishStateMgr().isVanished(p.getUniqueId())) return;
+    if (!e.getClickedBlock().getType().toString().equals("BIG_DRIPLEAF")) return;
+    e.setCancelled(true);
     }
-  }
 
 
   @Override
   public boolean isActive() {
-    return plugin.getSettings().getBoolean("InvisibilityFeatures.DisableDripLeaf");
+    return plugin.getSettings().getBoolean("InvisibilityFeatures.DisableDripLeaf",true);
   }
 }

--- a/src/main/java/de/myzelyam/supervanish/features/NoDripLeafTilt.java
+++ b/src/main/java/de/myzelyam/supervanish/features/NoDripLeafTilt.java
@@ -1,0 +1,28 @@
+package de.myzelyam.supervanish.features;
+
+import de.myzelyam.supervanish.SuperVanish;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class NoDripLeafTilt extends Feature{
+  public NoDripLeafTilt(SuperVanish plugin) {
+    super(plugin);
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  public void onInteract(PlayerInteractEvent e) {
+    if(plugin.getSettings().getBoolean("InvisibilityFeatures.DisableDripLeaf")) {
+      String material = e.getClickedBlock().getType().toString();
+      if (material.equals("BIG_DRIPLEAF")) {
+        e.setCancelled(true);
+      }
+    }
+  }
+
+
+  @Override
+  public boolean isActive() {
+    return plugin.getSettings().getBoolean("InvisibilityFeatures.DisableDripLeaf");
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,6 +27,8 @@ InvisibilityFeatures:
   ModifyTablistPackets: true
   # Should vanished players be unable to trigger the vibration of a sculk sensor?
   PreventSculkSensorActivation: true
+  # Should vanished players activate the tipping effect on Dripleaves.
+  DisableDripLeaf: true
 
   Fly:
     # Should invisible players be able to fly even if they aren't in creative/spectator mode?


### PR DESCRIPTION
This PR adds the option to enable/disable the tilting of drip leaves when a vanished player stands on them.