### PR TITLE
Fix ExternalInvisibility + Add PreventAdvancementGranting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,11 @@
         </repository>
     </repositories>
     <dependencies>
-        <!--Spigot API-->
+        <!--Paper API-->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.19.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!--Lombok-->

--- a/src/main/java/de/myzelyam/supervanish/features/FeatureMgr.java
+++ b/src/main/java/de/myzelyam/supervanish/features/FeatureMgr.java
@@ -51,6 +51,8 @@ public class FeatureMgr {
             Collections.singletonList(oneDotSeventeenOrHigher)));
         registeredFeatures.put("NoRaidTrigger", new FeatureInfo(NoRaidTrigger.class, plugin,
             Collections.singletonList(oneDotSeventeenOrHigher)));
+        registeredFeatures.put("NoAdvancementEarn", new FeatureInfo(NoAdvancementEarn.class, plugin,
+            Collections.singletonList(oneDotSeventeenOrHigher)));
     }
 
     public void enableFeatures() {

--- a/src/main/java/de/myzelyam/supervanish/features/NoAdvancementEarn.java
+++ b/src/main/java/de/myzelyam/supervanish/features/NoAdvancementEarn.java
@@ -1,0 +1,27 @@
+package de.myzelyam.supervanish.features;
+
+import com.destroystokyo.paper.event.player.PlayerAdvancementCriterionGrantEvent;
+import de.myzelyam.supervanish.SuperVanish;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+
+public class NoAdvancementEarn extends Feature {
+    public NoAdvancementEarn(SuperVanish plugin) {
+        super(plugin);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onAdvancementCriterionGrant(PlayerAdvancementCriterionGrantEvent e) {
+        Player p = e.getPlayer();
+        if (!plugin.getVanishStateMgr().isVanished(p.getUniqueId())) return;
+        e.setCancelled(true);
+    }
+
+    @Override
+    public boolean isActive() {
+        return plugin.getSettings().getBoolean("InvisibilityFeatures.PreventAdvancementEarning", true);
+    }
+}
+
+

--- a/src/main/java/de/myzelyam/supervanish/features/SilentOpenChest.java
+++ b/src/main/java/de/myzelyam/supervanish/features/SilentOpenChest.java
@@ -9,12 +9,15 @@
 package de.myzelyam.supervanish.features;
 
 import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
 import de.myzelyam.api.vanish.PlayerShowEvent;
 import de.myzelyam.supervanish.SuperVanish;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -124,10 +127,8 @@ public class SilentOpenChest extends Feature {
         Player p = e.getPlayer();
         if (playerStateInfoMap.containsKey(p)) {
             Location loc = e.getTo() != null ? e.getTo() : e.getFrom();
-            if (playerStateInfoMap.get(p).openLoc.distance(loc) > .5) {
-                p.closeInventory();
-                restoreState(playerStateInfoMap.get(p), p);
-                playerStateInfoMap.remove(p);
+            if (playerStateInfoMap.get(p).openLoc.distance(loc) > 3) {
+                p.teleport(playerStateInfoMap.get(p).openLoc);
             }
         }
     }
@@ -163,17 +164,9 @@ public class SilentOpenChest extends Feature {
                 || plugin.getVersionUtil().isOneDotXOrHigher(11) && additionalChestMaterials.contains(block.getType())))
             return;
         StateInfo stateInfo = StateInfo.extract(p);
-        p.setVelocity(new Vector(0, 0, 0));
         playerStateInfoMap.put(p, stateInfo);
         p.setGameMode(GameMode.SPECTATOR);
-    }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onChestClose(InventoryCloseEvent e) {
-        if (!(e.getPlayer() instanceof Player))
-            return;
-        final Player p = (Player) e.getPlayer();
-        if (!playerStateInfoMap.containsKey(p)) return;
         new BukkitRunnable() {
             @Override
             public void run() {
@@ -182,12 +175,11 @@ public class SilentOpenChest extends Feature {
                 restoreState(stateInfo, p);
                 playerStateInfoMap.remove(p);
             }
-        }.runTaskLater(plugin, 1);
+        }.runTaskLater(plugin, 2);
     }
 
     private void restoreState(StateInfo stateInfo, Player p) {
         p.setGameMode(stateInfo.gameMode);
-        p.teleport(p.getLocation().add(0, 0.2, 0));
         new BukkitRunnable() {
             @Override
             public void run() {
@@ -224,10 +216,9 @@ public class SilentOpenChest extends Feature {
 
     @Override
     public void onEnable() {
-        if (!plugin.getVersionUtil().isOneDotXOrHigher(19)) {
-            SilentOpenChestPacketAdapter packetAdapter = new SilentOpenChestPacketAdapter(this);
-            ProtocolLibrary.getProtocolManager().addPacketListener(packetAdapter);
-        }
+        plugin.getVersionUtil().isOneDotXOrHigher(19);
+        SilentOpenChestPacketAdapter packetAdapter = new SilentOpenChestPacketAdapter(this);
+        ProtocolLibrary.getProtocolManager().addPacketListener(packetAdapter);
     }
 
     private static class StateInfo {

--- a/src/main/java/de/myzelyam/supervanish/features/SilentOpenChestPacketAdapter.java
+++ b/src/main/java/de/myzelyam/supervanish/features/SilentOpenChestPacketAdapter.java
@@ -8,24 +8,18 @@
 
 package de.myzelyam.supervanish.features;
 
+import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.reflect.FieldAccessException;
-import com.comphenix.protocol.wrappers.EnumWrappers;
-import com.comphenix.protocol.wrappers.PlayerInfoData;
-import com.google.common.collect.ImmutableList;
-import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.comphenix.protocol.PacketType.Play.Server.*;
 
-/**
- * This is currently unused on Minecraft 1.19 or higher
- */
 public class SilentOpenChestPacketAdapter extends PacketAdapter {
 
     private final SilentOpenChest silentOpenChest;
@@ -34,7 +28,7 @@ public class SilentOpenChestPacketAdapter extends PacketAdapter {
 
     public SilentOpenChestPacketAdapter(SilentOpenChest silentOpenChest) {
         super(silentOpenChest.plugin, ListenerPriority.LOW, PLAYER_INFO, ABILITIES,
-                ENTITY_METADATA);
+                ENTITY_METADATA, GAME_STATE_CHANGE, NAMED_ENTITY_SPAWN);
         this.silentOpenChest = silentOpenChest;
     }
 
@@ -44,38 +38,10 @@ public class SilentOpenChestPacketAdapter extends PacketAdapter {
             Player receiver = event.getPlayer();
             if (receiver == null) return;
             if (event.getPacketType() == PLAYER_INFO) {
-                // multiple events share same packet object
-                event.setPacket(event.getPacket().shallowClone());
+                if (silentOpenChest.hasSilentlyOpenedChest(receiver))
+                    event.setCancelled(true);
 
-                List<PlayerInfoData> infoDataList = new ArrayList<>(
-                        event.getPacket().getPlayerInfoDataLists().read(0));
-                for (PlayerInfoData infoData : ImmutableList.copyOf(infoDataList)) {
-                    if (!silentOpenChest.plugin.getVisibilityChanger().getHider()
-                            .isHidden(infoData.getProfile().getUUID(), receiver)
-                            && silentOpenChest.plugin.getVanishStateMgr()
-                            .isVanished(infoData.getProfile().getUUID())) {
-                        Player vanishedTabPlayer = Bukkit.getPlayer(infoData.getProfile().getUUID());
-                        if (infoData.getGameMode() == EnumWrappers.NativeGameMode.SPECTATOR
-                                && silentOpenChest.hasSilentlyOpenedChest(vanishedTabPlayer)
-                                && event.getPacket().getPlayerInfoAction().read(0)
-                                == EnumWrappers.PlayerInfoAction.UPDATE_GAME_MODE) {
-                            int latency;
-                            try {
-                                latency = infoData.getLatency();
-                            } catch (NoSuchMethodError e) {
-                                latency = 21;
-                            }
-                            PlayerInfoData newData = new PlayerInfoData(infoData.getProfile(),
-                                    latency, EnumWrappers.NativeGameMode.SURVIVAL,
-                                    infoData.getDisplayName());
-                            infoDataList.remove(infoData);
-                            infoDataList.add(newData);
-                        }
-                    }
-                }
-                event.getPacket().getPlayerInfoDataLists().write(0, infoDataList);
             } else if (event.getPacketType() == GAME_STATE_CHANGE) {
-                // Currently unused due to ProtocolLib class loading bug
                 if (silentOpenChest.plugin.getVanishStateMgr().isVanished(
                         receiver.getUniqueId())) {
                     try {
@@ -101,6 +67,18 @@ public class SilentOpenChestPacketAdapter extends PacketAdapter {
                         event.setCancelled(true);
                     }
                 }
+            } else if (event.getPacketType() == NAMED_ENTITY_SPAWN) {
+                if (silentOpenChest.plugin.getVanishStateMgr().isVanished(
+                        receiver.getUniqueId())) {
+                    if (!silentOpenChest.hasSilentlyOpenedChest(receiver)) return;
+                    Entity entity = event.getPacket().getEntityModifier(receiver.getWorld()).read(0);
+                    if (entity instanceof Player) {
+                        Player p = (Player) entity;
+                        if (p.getGameMode() == GameMode.SPECTATOR) {
+                            event.setCancelled(true);
+                        }
+                    }
+                }
             }
         } catch (Exception | NoClassDefFoundError e) {
             if (!suppressErrors) {
@@ -118,5 +96,15 @@ public class SilentOpenChestPacketAdapter extends PacketAdapter {
                 }
             }
         }
+    }
+
+
+    private Entity getEntityById(World world, int entityId) {
+        for (Entity entity : world.getEntities()) {
+            if (entity.getEntityId() == entityId) {
+                return entity;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/de/myzelyam/supervanish/listeners/GeneralListener.java
+++ b/src/main/java/de/myzelyam/supervanish/listeners/GeneralListener.java
@@ -8,6 +8,7 @@
 
 package de.myzelyam.supervanish.listeners;
 
+import com.destroystokyo.paper.event.player.PlayerPickupExperienceEvent;
 import de.myzelyam.supervanish.SuperVanish;
 import de.myzelyam.supervanish.VanishPlayer;
 import de.myzelyam.supervanish.features.Broadcast;
@@ -110,6 +111,22 @@ public class GeneralListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onItemPickUp(PlayerPickupItemEvent e) {
+        try {
+            VanishPlayer vanishPlayer = plugin.getVanishPlayer(e.getPlayer());
+            if (vanishPlayer == null || !vanishPlayer.isOnlineVanished()) return;
+            if (!vanishPlayer.hasItemPickUpsEnabled())
+                e.setCancelled(true);
+            if (plugin.getSettings().getBoolean("RestrictiveOptions.PreventModifyingOwnInventory")
+                    && !vanishPlayer.getPlayer().hasPermission("sv.modifyowninv")) {
+                e.setCancelled(true);
+            }
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+
+    @EventHandler
+    public void onExperienceOrbPickup(PlayerPickupExperienceEvent e) {
         try {
             VanishPlayer vanishPlayer = plugin.getVanishPlayer(e.getPlayer());
             if (vanishPlayer == null || !vanishPlayer.isOnlineVanished()) return;

--- a/src/main/java/de/myzelyam/supervanish/utils/VersionUtil.java
+++ b/src/main/java/de/myzelyam/supervanish/utils/VersionUtil.java
@@ -32,7 +32,7 @@ public class VersionUtil {
     }
 
     public boolean isOneDotXOrHigher(int majorRelease) {
-        for (int i = majorRelease; i < 20; i++)
+        for (int i = majorRelease; i < 30; i++)
             if (version.contains("v1_" + i + "_R")) return true;
         return version.contains("v2_");
     }

--- a/src/main/java/de/myzelyam/supervanish/visibility/ServerListPacketListener.java
+++ b/src/main/java/de/myzelyam/supervanish/visibility/ServerListPacketListener.java
@@ -72,6 +72,7 @@ public class ServerListPacketListener extends PacketAdapter {
                     }
                 }
                 ping.setPlayers(wrappedGameProfiles);
+                e.getPacket().getServerPings().write(0, ping);
             }
         } catch (Exception er) {
             plugin.logException(er);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,6 +36,8 @@ InvisibilityFeatures:
   DisableDripLeaf: true
   # Should vanished players be unable to trigger raids?
   PreventRaidTriggering: true
+  # Should vanished players be unable to earn advancements? (works only on paper)
+  PreventAdvancementEarning: true
 
   Fly:
     # Should invisible players be able to fly even if they aren't in creative/spectator mode?


### PR DESCRIPTION
This PR makes the following changes

- Fixed an issue that caused ExternalInvisibility not to work in 1.19.4 and higher.

- Added `PreventAdvancementEarning` feature that prevents vanished players from earning advancements

- Improved SilentOpenChest

- Added a listener to prevent vanished players from picking up xp orbs (works only on paper)

- Fixed a bug that caused VersionUtil.isOneDotXOrHigher not to work in 1.20 and higher.