### PR TITLE
Fix packet leak bug

### DIFF
--- a/src/main/java/de/myzelyam/supervanish/SuperVanish.java
+++ b/src/main/java/de/myzelyam/supervanish/SuperVanish.java
@@ -18,10 +18,7 @@ import de.myzelyam.supervanish.hooks.PluginHookMgr;
 import de.myzelyam.supervanish.net.UpdateNotifier;
 import de.myzelyam.supervanish.utils.ExceptionLogger;
 import de.myzelyam.supervanish.utils.VersionUtil;
-import de.myzelyam.supervanish.visibility.ActionBarMgr;
-import de.myzelyam.supervanish.visibility.FileVanishStateMgr;
-import de.myzelyam.supervanish.visibility.ServerListPacketListener;
-import de.myzelyam.supervanish.visibility.VisibilityChanger;
+import de.myzelyam.supervanish.visibility.*;
 import de.myzelyam.supervanish.visibility.hiders.PreventionHider;
 import lombok.Getter;
 import org.bukkit.Bukkit;
@@ -100,6 +97,8 @@ public class SuperVanish extends JavaPlugin implements SuperVanishPlugin {
                 actionBarMgr = new ActionBarMgr(this);
             if (useProtocolLib && ServerListPacketListener.isEnabled(this))
                 ServerListPacketListener.register(this);
+            if (useProtocolLib)
+                PlayerSpawnPacketListener.register(this);
             registerEvents();
             new PluginHookMgr(this);
             featureMgr = new FeatureMgr(this);

--- a/src/main/java/de/myzelyam/supervanish/visibility/PlayerSpawnPacketListener.java
+++ b/src/main/java/de/myzelyam/supervanish/visibility/PlayerSpawnPacketListener.java
@@ -1,0 +1,44 @@
+package de.myzelyam.supervanish.visibility;
+
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import de.myzelyam.supervanish.SuperVanish;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import static com.comphenix.protocol.PacketType.Play.Server.*;
+
+public class PlayerSpawnPacketListener extends PacketAdapter {
+
+    private final SuperVanish plugin;
+
+    public PlayerSpawnPacketListener(SuperVanish plugin) {
+        super(plugin, ListenerPriority.NORMAL, NAMED_ENTITY_SPAWN);
+        this.plugin = plugin;
+    }
+
+    public static void register(SuperVanish plugin) {
+        ProtocolLibrary.getProtocolManager().addPacketListener(new PlayerSpawnPacketListener(plugin));
+    }
+
+    @Override
+    public void onPacketSending(PacketEvent event) {
+        // This prevents packet leaking vanished players around a non-admin player when he logs in
+        try {
+            if (event.getPacketType() == NAMED_ENTITY_SPAWN) {
+                Player p = event.getPlayer();
+                Entity entity = event.getPacket().getEntityModifier(p.getWorld()).read(0);
+                if (entity instanceof Player) {
+                    Player target = (Player) entity;
+                    if (plugin.getVanishStateMgr().isVanished(target.getUniqueId()) && !p.hasPermission("sv.see")) {
+                        event.setCancelled(true);
+                    }
+                }
+            }
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+}


### PR DESCRIPTION
Currently, when a player logs in, they receive a `NAMED_ENTITY_SPAWN` packet for all players around them, even vanished players. This allows players using appropriate mods to know if there are vanished players around them.

This PR solves this problem by blocking the packet if the player is vanished.