### PR TITLE
Fix /msg command on vanished players

### DIFF
--- a/src/main/java/de/myzelyam/supervanish/SuperVanish.java
+++ b/src/main/java/de/myzelyam/supervanish/SuperVanish.java
@@ -174,6 +174,7 @@ public class SuperVanish extends JavaPlugin implements SuperVanishPlugin {
         pluginManager.registerEvents(new GeneralListener(this), this);
         pluginManager.registerEvents(new PlayerBlockModifyListener(this), this);
         pluginManager.registerEvents(new WorldChangeListener(this), this);
+        pluginManager.registerEvents(new CommandListener(this), this);
         if (versionUtil.isOneDotXOrHigher(10)) {
             pluginManager.registerEvents(new TabCompleteListener(this), this);
         }

--- a/src/main/java/de/myzelyam/supervanish/listeners/CommandListener.java
+++ b/src/main/java/de/myzelyam/supervanish/listeners/CommandListener.java
@@ -1,0 +1,62 @@
+package de.myzelyam.supervanish.listeners;
+
+import de.myzelyam.supervanish.SuperVanish;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class CommandListener implements Listener {
+
+    private final SuperVanish plugin;
+    private final FileConfiguration config;
+
+    public CommandListener(SuperVanish plugin) {
+        this.plugin = plugin;
+        config = plugin.getSettings();
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    private void onCommand(PlayerCommandPreprocessEvent e) {
+        try {
+            if (!plugin.getSettings().getBoolean("MessageOptions.DisableMsgCommand", true)) return;
+            Player p = e.getPlayer();
+            if (p.hasPermission("sv.bypass")) return;
+            String[] args = e.getMessage().split(" ");
+            if (args.length < 3) return;
+            Player target = Bukkit.getPlayer(args[1]);
+            if (target == null || !plugin.getVanishStateMgr().isVanished(target.getUniqueId())) return;
+
+            String message = plugin.getMessage("FakeNotOnline");
+
+            String command = e.getMessage().replace("/", "");
+            String cmd = command.split(" ")[0];
+            String[] blockedCommands = {"msg", "tell", "w"};
+            CommandMap commandMap;
+            try {
+                commandMap = (CommandMap) Bukkit.getServer().getClass().getMethod("getCommandMap").invoke(Bukkit.getServer());
+            } catch (Exception ignored) {
+                return;
+            }
+
+            for (String blockedCommand : blockedCommands) {
+                if (cmd.equalsIgnoreCase("minecraft:" + blockedCommand)) {
+                    e.getPlayer().sendMessage(message);
+                    e.setCancelled(true);
+                    return;
+                } else if (cmd.equalsIgnoreCase(blockedCommand) && !(commandMap.getCommand(blockedCommand) instanceof PluginCommand)) {
+                    e.getPlayer().sendMessage(message);
+                    e.setCancelled(true);
+                    return;
+                }
+            }
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+}

--- a/src/main/java/de/myzelyam/supervanish/listeners/CommandListener.java
+++ b/src/main/java/de/myzelyam/supervanish/listeners/CommandListener.java
@@ -32,7 +32,7 @@ public class CommandListener implements Listener {
             Player target = Bukkit.getPlayer(args[1]);
             if (target == null || !plugin.getVanishStateMgr().isVanished(target.getUniqueId())) return;
 
-            String message = plugin.getMessage("FakeNotOnline");
+            String message = plugin.getMessage("FakeNotFound");
 
             String command = e.getMessage().replace("/", "");
             String cmd = command.split(" ")[0];

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -99,6 +99,9 @@ MessageOptions:
     # Should there only be fake join/quit messages and no admin announcements?
     SendMessageOnlyToUsers: false
 
+  # Should SV prevent the use of the /msg command on vanished players?
+  DisableMsgCommand: true
+
   # Should SV hide the real join/leave messages of invisible players?
   HideRealJoinQuitMessages: true
   # Should SV hide leave messages for invisible players if 'VanishStateFeatures->ReappearOnQuit' is turned on?

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -29,6 +29,7 @@ Messages:
   InvalidUsage: '&cInvalid usage, you can use &6/sv help&c for a list of commands.'
   VanishMessage: '&e%p% left the game'
   ReappearMessage: '&e%p% joined the game'
+  FakeNotOnline: '§cNo player was found'
   VanishMessageWithPermission: '&a[SV] %p% vanished.'
   ReappearMessageWithPermission: '&a[SV] %p% reappeared.'
   OnVanish: '&aYou are now invisible!'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -29,7 +29,7 @@ Messages:
   InvalidUsage: '&cInvalid usage, you can use &6/sv help&c for a list of commands.'
   VanishMessage: '&e%p% left the game'
   ReappearMessage: '&e%p% joined the game'
-  FakeNotOnline: '§cNo player was found'
+  FakeNotFound: '§cNo player was found'
   VanishMessageWithPermission: '&a[SV] %p% vanished.'
   ReappearMessageWithPermission: '&a[SV] %p% reappeared.'
   OnVanish: '&aYou are now invisible!'


### PR DESCRIPTION
Currently minecraft message commands (`/minecraft:msg` `/minecraft:tell` `/minecraft:w`) work on vanished players.
This PR fixes this problem by adding a `MessageOptions.DisableMsgCommand` option that returns an error message when someone tries to send a message to a vanished player. The error message can be customized with the setting `FakeNotFound`.