### PR TITLE
Paper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,10 @@
         </repository>
     </repositories>
     <dependencies>
-        <!--Spigot API-->
+        <!--Paper API-->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/de/myzelyam/supervanish/features/FeatureMgr.java
+++ b/src/main/java/de/myzelyam/supervanish/features/FeatureMgr.java
@@ -29,7 +29,8 @@ public class FeatureMgr {
 
     private static final Requirement<FeatureInfo> protocolLibInstalled = featureInfo -> Bukkit.getPluginManager().isPluginEnabled("ProtocolLib"),
             oneDotEightOrHigher = featureInfo -> featureInfo.getPlugin().getVersionUtil().isOneDotXOrHigher(8),
-            oneDotSeventeenOrHigher = featureInfo -> featureInfo.getPlugin().getVersionUtil().isOneDotXOrHigher(17);
+            oneDotSeventeenOrHigher = featureInfo -> featureInfo.getPlugin().getVersionUtil().isOneDotXOrHigher(17),
+            paperServer = featureInfo -> Bukkit.getServer().getName().equals("Paper");
     private final Map<String, FeatureInfo> registeredFeatures = new HashMap<>();
     private final Set<Feature> activeFeatures = new HashSet<>();
     private final SuperVanish plugin;
@@ -51,6 +52,10 @@ public class FeatureMgr {
             Collections.singletonList(oneDotSeventeenOrHigher)));
         registeredFeatures.put("NoRaidTrigger", new FeatureInfo(NoRaidTrigger.class, plugin,
             Collections.singletonList(oneDotSeventeenOrHigher)));
+        registeredFeatures.put("NoMobSpawn", new FeatureInfo(NoMobSpawn.class, plugin,
+            Collections.singletonList(paperServer)));
+        registeredFeatures.put("HideAdvancementMessages", new FeatureInfo(HideAdvancementMessages.class, plugin,
+            Collections.singletonList(paperServer)));
     }
 
     public void enableFeatures() {

--- a/src/main/java/de/myzelyam/supervanish/features/HideAdvancementMessages.java
+++ b/src/main/java/de/myzelyam/supervanish/features/HideAdvancementMessages.java
@@ -1,0 +1,35 @@
+package de.myzelyam.supervanish.features;
+
+import de.myzelyam.supervanish.SuperVanish;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+
+// This feature is paper-only because the PlayerAdvancementDoneEvent#message() method doesn't exist in Spigot
+public class HideAdvancementMessages extends Feature {
+
+    public HideAdvancementMessages(SuperVanish plugin) {
+        super(plugin);
+    }
+
+    @EventHandler
+    public void onAdvancementDone(PlayerAdvancementDoneEvent e) {
+        try {
+            Player p = e.getPlayer();
+            Component message = e.message();
+            if (message == null) return;
+            if (!plugin.getVanishStateMgr().isVanished(p.getUniqueId())) return;
+            if (e.message() == null) return;
+            e.message(null);
+            p.sendMessage(message);
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+
+    @Override
+    public boolean isActive() {
+        return plugin.getSettings().getBoolean("MessageOptions.HideAdvancementMessages", true);
+    }
+}

--- a/src/main/java/de/myzelyam/supervanish/features/NoMobSpawn.java
+++ b/src/main/java/de/myzelyam/supervanish/features/NoMobSpawn.java
@@ -1,0 +1,72 @@
+package de.myzelyam.supervanish.features;
+
+import com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent;
+import com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent;
+import com.destroystokyo.paper.event.entity.SkeletonHorseTrapEvent;
+import de.myzelyam.supervanish.SuperVanish;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+
+import java.util.List;
+
+public class NoMobSpawn extends Feature {
+
+
+    public NoMobSpawn(SuperVanish plugin) {
+        super(plugin);
+    }
+
+    @EventHandler
+    public void onSkeletonHorseTrap(SkeletonHorseTrapEvent e) {
+        try {
+            List<HumanEntity> humans = e.getEligibleHumans();
+            int humansCount = humans.size();
+            for (HumanEntity human : humans) {
+                if (human instanceof Player) {
+                    Player p = (Player) human;
+                    if (plugin.getVanishStateMgr().isVanished(p.getUniqueId())) {
+                        humansCount--;
+                    }
+                }
+            }
+            if (humansCount == 0)
+                e.setCancelled(true);
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+
+    @EventHandler
+    public void onEntitySpawn(PlayerNaturallySpawnCreaturesEvent e) {
+        try {
+            if (plugin.getVanishStateMgr().isVanished(e.getPlayer().getUniqueId()))
+                e.setCancelled(true);
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+    @EventHandler
+    public void onEntitySpawnerSpawn(PreSpawnerSpawnEvent e) {
+        try {
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getWorld().equals(e.getSpawnerLocation().getWorld()) &&
+                        p.getLocation().distanceSquared(e.getSpawnerLocation()) <= 256 &&
+                        p.getGameMode() != GameMode.SPECTATOR &&
+                        !plugin.getVanishStateMgr().isVanished(p.getUniqueId()))
+                    return;
+            }
+            e.setCancelled(true);
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+
+    @Override
+    public boolean isActive() {
+        return plugin.getSettings().getBoolean("InvisibilityFeatures.PreventMobSpawning", true);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,6 +36,8 @@ InvisibilityFeatures:
   DisableDripLeaf: true
   # Should vanished players be unable to trigger raids?
   PreventRaidTriggering: true
+  # Should vanished players be unable to make spawn mobs? (paper only)
+  PreventMobSpawning: true
 
   Fly:
     # Should invisible players be able to fly even if they aren't in creative/spectator mode?
@@ -101,6 +103,8 @@ MessageOptions:
 
   # Should SV hide the real join/leave messages of invisible players?
   HideRealJoinQuitMessages: true
+  # Should SV hide the advancement messages of invisible players (only send it to the player)? (paper only)
+  HideAdvancementMessages: true
   # Should SV hide leave messages for invisible players if 'VanishStateFeatures->ReappearOnQuit' is turned on?
   # Overrides 'HideRealJoinQuitMessages'
   ReappearOnQuitHideLeaveMsg: true


### PR DESCRIPTION
This PR changes from the Spigot API to the PaperMC API and adds these features:
- PreventMobSpawn: prevents vanished players from spawning mobs naturally or with a spawner, and from triggering skeleton horse traps.
- HideAdvancementMessages: prevents advancement messages from being sent if the player who obtained the advancement is vanished.

If the plugin is used on a non-paper server, these two features are not triggered, but no errors are thrown (tested on Spigot 1.20.1).

Please note that the API change may make it difficult to develop new features, as some objects/methods may pass compilation but not exists for non-paper servers (such as `org.bukkit.event.player.PlayerAdvancementDoneEvent#message()`).
